### PR TITLE
Add metadata to example rule; add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.terraform*
+.DS_Store
+venv/

--- a/example_custom_rule/long_description.rego
+++ b/example_custom_rule/long_description.rego
@@ -1,6 +1,20 @@
 # Policies must have description of at least 25 characters.
 package rules.long_description
 
+__rego__metadoc__ := {
+  "id": "CUSTOM_0001",
+  "title": "IAM policies must have a description of at least 25 characters",
+  "description": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
+  "custom": {
+    "controls": {
+      "CORPORATE-POLICY": [
+        "CORPORATE-POLICY_1.1"
+      ]
+    },
+    "severity": "Low"
+  }
+}
+
 resource_type = "aws_iam_policy"
 
 default allow = false


### PR DESCRIPTION
This PR:

- Adds some metadata to the example rule
- Adds a `.gitignore`

Here's Regula's output for running the updated rule against the `infra_tf` project in this repo:

```
{
  "rule_results": [
    {
      "controls": [
        "CORPORATE-POLICY_1.1"
      ],
      "filepath": "infra_tf",
      "platform": "terraform",
      "provider": "aws",
      "resource_id": "aws_iam_policy.basically_allow_all",
      "resource_type": "aws_iam_policy",
      "rule_description": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
      "rule_id": "CUSTOM_0001",
      "rule_message": "",
      "rule_name": "long_description",
      "rule_result": "FAIL",
      "rule_severity": "Low",
      "rule_summary": "IAM policies must have a description of at least 25 characters"
    },
    {
      "controls": [
        "CORPORATE-POLICY_1.1"
      ],
      "filepath": "infra_tf",
      "platform": "terraform",
      "provider": "aws",
      "resource_id": "aws_iam_policy.basically_deny_all",
      "resource_type": "aws_iam_policy",
      "rule_description": "Per company policy, it is required for all IAM policies to have a description of at least 25 characters.",
      "rule_id": "CUSTOM_0001",
      "rule_message": "",
      "rule_name": "long_description",
      "rule_result": "PASS",
      "rule_severity": "Low",
      "rule_summary": "IAM policies must have a description of at least 25 characters"
    }
  ],
  "summary": {
    "filepaths": [
      "infra_tf"
    ],
    "rule_results": {
      "FAIL": 1,
      "PASS": 1,
      "WAIVED": 0
    },
    "severities": {
      "Critical": 0,
      "High": 0,
      "Informational": 0,
      "Low": 1,
      "Medium": 0,
      "Unknown": 0
    }
  }
}
```